### PR TITLE
Revisit ledger closing procedure

### DIFF
--- a/ledger/archival_test.go
+++ b/ledger/archival_test.go
@@ -108,6 +108,7 @@ func TestArchival(t *testing.T) {
 	const archival = true
 	l, err := OpenLedger(logging.Base(), dbName, inMem, genesisInitState, archival)
 	require.NoError(t, err)
+	defer l.Close()
 	wl := &wrappedLedger{
 		l: l,
 	}
@@ -190,6 +191,7 @@ func TestArchivalRestart(t *testing.T) {
 
 	l, err = OpenLedger(logging.Base(), dbPrefix, inMem, genesisInitState, archival)
 	require.NoError(t, err)
+	defer l.Close()
 
 	err = l.blockDBs.rdb.Atomic(func(tx *sql.Tx) error {
 		latest, err = blockLatest(tx)
@@ -248,6 +250,7 @@ func TestArchivalFromNonArchival(t *testing.T) {
 	archival = true
 	l, err = OpenLedger(logging.Base(), dbPrefix, inMem, genesisInitState, archival)
 	require.NoError(t, err)
+	defer l.Close()
 
 	err = l.blockDBs.rdb.Atomic(func(tx *sql.Tx) error {
 		latest, err = blockLatest(tx)

--- a/ledger/eval_test.go
+++ b/ledger/eval_test.go
@@ -53,6 +53,7 @@ func TestBlockEvaluator(t *testing.T) {
 	const archival = true
 	l, err := OpenLedger(logging.Base(), dbName, inMem, genesisInitState, archival)
 	require.NoError(t, err)
+	defer l.Close()
 
 	blks := genesisInitState.Blocks
 	newBlock := bookkeeping.MakeBlock(blks[len(blks)-1].BlockHeader)

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -94,9 +94,6 @@ func OpenLedger(
 	defer func() {
 		if err != nil {
 			l.Close()
-			if l.blockQ != nil {
-				l.blockQ.close()
-			}
 		}
 	}()
 
@@ -244,9 +241,12 @@ func initBlocksDB(tx *sql.Tx, l *Ledger, initBlocks []bookkeeping.Block, isArchi
 // and goroutines used by trackers).
 func (l *Ledger) Close() {
 	l.trackerDBs.close()
-	l.blockQ.close()
 	l.blockDBs.close()
 	l.trackers.close()
+	if l.blockQ != nil {
+		l.blockQ.close()
+		l.blockQ = nil
+	}
 }
 
 // RegisterBlockListeners registers listeners that will be called when a

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -193,8 +193,9 @@ func TestLedgerBasic(t *testing.T) {
 	genesisInitState, _ := testGenerateInitState(t, protocol.ConsensusCurrentVersion)
 	const inMem = true
 	const archival = true
-	_, err := OpenLedger(logging.Base(), t.Name(), inMem, genesisInitState, archival)
+	l, err := OpenLedger(logging.Base(), t.Name(), inMem, genesisInitState, archival)
 	require.NoError(t, err, "could not open ledger")
+	defer l.Close()
 }
 
 func TestLedgerBlockHeaders(t *testing.T) {
@@ -208,6 +209,7 @@ func TestLedgerBlockHeaders(t *testing.T) {
 	const archival = true
 	l, err := OpenLedger(logging.Base(), t.Name(), inMem, genesisInitState, archival)
 	a.NoError(err, "could not open ledger")
+	defer l.Close()
 
 	lastBlock, err := l.Block(l.Latest())
 	a.NoError(err, "could not get last block")
@@ -344,6 +346,7 @@ func TestLedgerSingleTx(t *testing.T) {
 	const archival = true
 	l, err := OpenLedger(logging.Base(), t.Name(), inMem, genesisInitState, archival)
 	a.NoError(err, "could not open ledger")
+	defer l.Close()
 
 	proto := config.Consensus[protocol.ConsensusV7]
 	poolAddr := testPoolAddr
@@ -528,6 +531,7 @@ func TestLedgerSingleTxApplyData(t *testing.T) {
 	const archival = true
 	l, err := OpenLedger(logging.Base(), t.Name(), inMem, genesisInitState, archival)
 	a.NoError(err, "could not open ledger")
+	defer l.Close()
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 	poolAddr := testPoolAddr

--- a/ledger/perf_test.go
+++ b/ledger/perf_test.go
@@ -90,6 +90,7 @@ func BenchmarkManyAccounts(b *testing.B) {
 	const archival = true
 	l, err := OpenLedger(logging.Base(), dbName, inMem, genesisInitState, archival)
 	require.NoError(b, err)
+	defer l.Close()
 
 	blks := genesisInitState.Blocks
 	blk := blks[len(blks)-1]
@@ -142,6 +143,7 @@ func BenchmarkValidate(b *testing.B) {
 	const archival = true
 	l, err := OpenLedger(logging.Base(), dbName, inMem, genesisInitState, archival)
 	require.NoError(b, err)
+	defer l.Close()
 
 	blks := genesisInitState.Blocks
 	blk := blks[len(blks)-1]


### PR DESCRIPTION
* Ensure proper resource freeing on errors in OpenLedger
* Prevent possible double closing of blocks queue
* Close ledger in tests

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Explain the goal of this change and what problem it is solving.

## Test Plan

How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale.

