### PR TITLE
Update the test to reflect the change of the default filter

### DIFF
--- a/txnsync/bloomFilter_test.go
+++ b/txnsync/bloomFilter_test.go
@@ -187,23 +187,26 @@ func TestHint(t *testing.T) {
 		txnGroups := getTxnGroups(genesisHash, genesisID)
 		bf := s.makeBloomFilter(encodingParams, txnGroups, nil)
 
+		defaultFilterType := xorBloomFilter32
 		switch bf.filter.(type) {
 		case *bloom.XorFilter:
 			//ok
 		default:
 			t.Errorf("expect bloom.XorFilter")
 		}
-		require.Equal(t, xorBloomFilter32, bf.filterType)
+		require.Equal(t, defaultFilterType, bf.filterType)
 
-		// Change the filter of bf to XorFilter
-		bf.filter, bf.filterType = filterFactoryXor32(len(txnGroups), &s)
+		// Change the filter of bf to other than the default filter i.e. XorFilter8
+		bf.filter, bf.filterType = filterFactoryXor8(len(txnGroups), &s)
 
 		// Pass bf as a hint.
 		bf2 := s.makeBloomFilter(encodingParams, txnGroups, &bf)
 
-		// If the filter of bf2 is XorFilter, then the hint was used.
+		// If the filter of bf2 is not defaultFilterType (i.e. is XorFilter8), then the hint was used.
+		// The hint must be used, and the filter should not be the default filter.
+		require.NotEqual(t, defaultFilterType, bf2.filterType)
 		switch bf2.filter.(type) {
-		case *bloom.XorFilter:
+		case *bloom.XorFilter8:
 			//ok
 		default:
 			t.Errorf("expect bloom.Filter")
@@ -213,14 +216,14 @@ func TestHint(t *testing.T) {
 		txnGroups = txnGroups[2:]
 		bf2 = s.makeBloomFilter(encodingParams, txnGroups, &bf)
 
-		// If the filter of bf2 is XorFilter8, then the hint was not used
+		// If the filter of bf2 is XorFilter (i.e. defaultFilterType), then the hint was not used
 		switch bf2.filter.(type) {
 		case *bloom.XorFilter:
 			//ok
 		default:
 			t.Errorf("expect bloom.XorFilter")
 		}
-		require.Equal(t, xorBloomFilter32, bf2.filterType)
+		require.Equal(t, defaultFilterType, bf2.filterType)
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary
The change of the default filter rendered part of the TestHint trivial, where the test may pass even if the hint is not used when it should be used. 
This change fixes it, and adds more clarity to the test to make this point. 
<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
